### PR TITLE
Add missing commas

### DIFF
--- a/GameData/DiRT/DiRT.version
+++ b/GameData/DiRT/DiRT.version
@@ -12,12 +12,12 @@
     "MAJOR": 1,
     "MINOR": 4,
     "PATCH": 2
-  }
+  },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,
     "MINOR": 4,
     "PATCH": 2
-  }
+  },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,
     "MINOR": 4,


### PR DESCRIPTION
.version files are in JSON format, which requires commas between different key/value pairs. Currently these are missing in two places in this mod's .version file.

This pull request adds the missing commas.